### PR TITLE
Beam calculation bug fixes

### DIFF
--- a/calc_beam.pro
+++ b/calc_beam.pro
@@ -164,8 +164,8 @@ equi = calc_equi(pos,$
                  Bphi, q0, qwall,qindex,$
                  Bp0, Bpa, Bpindex)
 end if else begin
-
 equi = read_equi(pos, equifile)
+endelse
 psi   = equi.psi
 
 ; get the electron density (parabolic density profile assumed)

--- a/calc_beam.pro
+++ b/calc_beam.pro
@@ -163,7 +163,7 @@ equi = calc_equi(pos,$
                  R0,a,sharf,elong,$
                  Bphi, q0, qwall,qindex,$
                  Bp0, Bpa, Bpindex)
-end if else begin
+endif else begin
 equi = read_equi(pos, equifile)
 endelse
 psi   = equi.psi

--- a/calc_beam.pro
+++ b/calc_beam.pro
@@ -70,7 +70,11 @@ function calc_beam, pos,B0,Bv,chi,w0,Bdens0,edens0,Qion,Qemit,$
 ;   where k is the distance to the beam port B0
 ;
 ; - the emission rate is taken to be 2e13 (in the same order as what M. Turnyanskiy predicts)
-
+; S. Gibson 04/2020 - Noticed a bug with the beam emission ~ 6 orders
+;                    of magnitude smaller than that from the beam file.
+;             I think the units of the emission rate specified here
+;             is photons/cm^3/s. If this is the case then we need the
+;             same conversion to photons/m^3/s ie. emission*1e6.
 
 ; Numerical integration setting:
 nl = 100    ; number of numerical integration points
@@ -134,7 +138,7 @@ if (count ne 0) then begin
                     Bphi,q0,qwall,qindex,$
                     Bp0,Bpa,Bpindex)
   endif else begin
-    equi  = read_equi(Bpt, equifile)		; else: get the equilibrium from the file
+  equi  = read_equi(Bpt, equifile)		; else: get the equilibrium from the file
   endelse
   psi   = equi.psi
 
@@ -178,8 +182,8 @@ Bdenstmp = Bdens*1e-12
 edenstmp = edens*1e-12
 Qemittmp = Qemit*1e20
 emission = Bdenstmp * edenstmp * Qemittmp
-
 ; make the structure and return it
+emission = emission * 1e6 ;m^-3
 beam ={Bdens:Bdens, edens:edens, emission:emission}
 return, beam
 

--- a/calc_beam.pro
+++ b/calc_beam.pro
@@ -158,6 +158,13 @@ Bdens = (Bdensc*w0)/(w) * exp(-d^2/w^2)
 ; calculate the equilibrium to find the psi
 ;equi  = calc_equi(pos,R0,a,shafr,elong,Bphi,q0,qwall,qindex,Bp0,Bpa,Bpindex)
 
+if strcmp('none',equifile,/fold_case) then begin
+equi = calc_equi(pos,$
+                 R0,a,sharf,elong,$
+                 Bphi, q0, qwall,qindex,$
+                 Bp0, Bpa, Bpindex)
+end if else begin
+
 equi = read_equi(pos, equifile)
 psi   = equi.psi
 

--- a/calc_beamdir.pro
+++ b/calc_beamdir.pro
@@ -92,7 +92,7 @@ if ~oldbeam then begin
     idx = where(dp lt -1.0,count)	; can happen due to round-off error
     if count ne 0 then dp[idx]=-1.0
     xi  = acos(dp)
-    print,xi[0]
+    ;print,xi[0]
     ; get the propability
     p   = exp(-xi^2/div^2)
     p   = p/total(p)
@@ -199,7 +199,7 @@ endif else begin
 
     ; put all data in the structure
     structarr[k].avvel = avvel[*,k]
-    print, 'average velocity distribution', avvel[*,k]
+    ;print, 'average velocity distribution', avvel[*,k]
     structarr[k].vel   = vel
     structarr[k].p     = p
   endfor

--- a/read_beam.pro
+++ b/read_beam.pro
@@ -66,6 +66,6 @@ emission = interpolate(ratebes2,xi,yi,zi)
 emission = 1e6*emission
 
 beam ={Bdens:Bdens, edens:edens, emission:emission}
-return, beam
 
+return, beam
 end

--- a/read_equi.pro
+++ b/read_equi.pro
@@ -57,6 +57,7 @@ Zi = (Zpos-min(Z))/(max(Z)-min(Z)) * (n_elements(Z)-1)
 BR   = reform(interpolate(Bfld[0,*,*],Ri,Zi),1,n)
 BZ   = reform(interpolate(Bfld[1,*,*],Ri,Zi),1,n)
 Bphi = reform(interpolate(Bfld[2,*,*],Ri,Zi),1,n)
+
 psi  = reform(interpolate(transpose(fluxcoord),Ri,Zi),1,n)
 
 ; create the B-field vector in xyz-coordinates
@@ -75,5 +76,6 @@ if (count ne 0) then theta(idx) += 2*!pi
 
 equi = {Bfld:Bfld, psi:psi, theta:theta, Rm:Rm}
 ; return the result
+
 return, equi
 end

--- a/spectrum_calc.pro
+++ b/spectrum_calc.pro
@@ -122,7 +122,6 @@ print,FORMAT='($,A)',"................................... "
 ;----------------------------------------------------------------------------------
 common physics, c, kb, em, e, pm, nm, RydInf
 
-;fname = ['/home/sgibson/PycharmProjects/msesim/equi/physics/','physic_constants.xml']
 info = routine_info('msesim', /SOURCE)
 msesimRootDir = file_dirname(info.path)
 

--- a/test_beam.pro
+++ b/test_beam.pro
@@ -19,8 +19,8 @@
 
 pro test_beam, calc=calc
 ; tokamak and field parameters
-R0    = 0.83
-a     = 0.60
+R0    = 0.88 ;0.83 for MAST 
+a     = 0.65 ;0.6 for MAST
 Bphi  = -0.5
 q0    = 1.0
 qa    = 3.0
@@ -34,9 +34,9 @@ elong = 1.66
 ; beam parameters
 B0   =[0,-2,0]
 w0   =0.1
-xi   =70
-delta=90
-chi  =1.2
+xi   = 70
+delta= 90
+chi  = 1.2
 
 Bdens0=5e15
 edens0=5e19


### PR DESCRIPTION
Fixed up a few bugs pertaining to the beam emission calculation.

Units error in the emission of particles from the beam (cm^-3) meant that beam emission was ~6 orders of magnitude too low if no beam file was specified.